### PR TITLE
Add working links for libpagno* libraties

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ rm -r ~/.sane
   Fixed on Ubuntu 20.04 with:
   ```bash
   cd /tmp
-  wget http://mirrors.kernel.org/ubuntu/pool/main/p/pango1.0/libpango-1.0-0_1.42.4-7_amd64.deb
-  wget http://mirrors.kernel.org/ubuntu/pool/main/p/pango1.0/libpangocairo-1.0-0_1.42.4-7_amd64.deb
-  wget http://mirrors.kernel.org/ubuntu/pool/main/p/pango1.0/libpangoft2-1.0-0_1.42.4-7_amd64.deb
+  wget http://launchpadlibrarian.net/438303557/libpango-1.0-0_1.42.4-7_amd64.deb
+  wget http://launchpadlibrarian.net/438303558/libpangocairo-1.0-0_1.42.4-7_amd64.deb
+  wget http://launchpadlibrarian.net/438303559/libpangoft2-1.0-0_1.42.4-7_amd64.deb
   cd /opt/PomoDoneApp
   sudo dpkg -x /tmp/libpango-1.0-0_1.42.4-7_amd64.deb .
   sudo dpkg -x /tmp/libpangocairo-1.0-0_1.42.4-7_amd64.deb .


### PR DESCRIPTION
Specific version of  libpagno* libraries are no longer available at http://mirrors.kernel.org. I found them on https://launchpad.net/ubuntu/focal/amd64/libpango-1.0-0/1.42.4-7, https://launchpad.net/ubuntu/focal/amd64/libpangocairo-1.0-0/1.42.4-7 and https://launchpad.net/ubuntu/focal/amd64/libpangoft2-1.0-0/1.42.4-7 so I added new links.